### PR TITLE
Fix navbar visibility in dark theme and add proper spacing

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -59,7 +59,11 @@ const Navigation: React.FC = () => {
             </div>
 
             <span className={`font-bold text-xl transition-colors ${
-                isScrolled ? 'text-gray-900' : 'text-white'
+                isScrolled 
+                  ? theme === 'dark' 
+                    ? 'text-white' 
+                    : 'text-gray-900'
+                  : 'text-white'
               }`}>
                 Open Source World
             </span>
@@ -73,7 +77,9 @@ const Navigation: React.FC = () => {
                 whileHover={{ y: -2 }}
                 onClick={() => scrollToSection(item.href)}
                 className={`font-medium transition-colors ${isScrolled
-                  ? 'text-secondary-700 hover:text-primary-600'
+                  ? theme === 'dark'
+                    ? 'text-white hover:text-gray-200'
+                    : 'text-secondary-700 hover:text-primary-600'
                   : 'text-white/90 hover:text-white'
                   }`}
               >
@@ -105,7 +111,11 @@ const Navigation: React.FC = () => {
             <motion.button
               whileTap={{ scale: 0.9 }}
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-              className={`p-2 rounded-lg ${isScrolled ? 'text-secondary-700' : 'text-white'
+              className={`p-2 rounded-lg ${isScrolled 
+                ? theme === 'dark' 
+                  ? 'text-white' 
+                  : 'text-secondary-700' 
+                : 'text-white'
                 }`}
             >
               {isMobileMenuOpen ? <FaTimes size={24} /> : <FaBars size={24} />}

--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -1,8 +1,7 @@
-import React, { use } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import { FaGithub, FaRocket, FaUsers, FaGlobe } from 'react-icons/fa';
 import { itemVariants, containerVariants } from '../../utils/animations';
-import { ThemeProvider } from '../../context/ThemeContext';
 import { useTheme } from '../../context/ThemeContext';
 
 const HeroSection: React.FC = () => {
@@ -13,12 +12,12 @@ const HeroSection: React.FC = () => {
     }
   };
 
-  const {theme, toggleTheme} = useTheme();
+  const {theme} = useTheme();
 
   // Blue gradient hero background
   const heroBackgroundStyle = theme === 'light' 
-    ? 'min-h-screen relative overflow-hidden flex items-center bg-gradient-to-br from-[#073f70] to-[#1f84d6]'
-    : 'min-h-screen relative overflow-hidden flex items-center bg-gradient-to-br from-[#0a0e14] to-[#1a2332]';
+    ? 'min-h-screen relative overflow-hidden flex items-center pt-24 md:pt-32 bg-gradient-to-br from-[#073f70] to-[#1f84d6]'
+    : 'min-h-screen relative overflow-hidden flex items-center pt-24 md:pt-32 bg-gradient-to-br from-[#0a0e14] to-[#1a2332]';
 
   return (
     <section 


### PR DESCRIPTION
#26 
- Fix navigation text visibility when scrolled in dark theme
- Add proper spacing above hero section to prevent navbar overlap
- Improve theme-aware styling for logo, navigation links, and mobile menu
- Clean up unused imports in HeroSection component
<img width="931" height="289" alt="image" src="https://github.com/user-attachments/assets/8d4ad4df-eb77-4a1c-a745-e80689ec9507" />

before :
<img width="1046" height="103" alt="image" src="https://github.com/user-attachments/assets/6997a432-b7cf-4c48-9b8a-523d7fd5255a" />
After:
<img width="860" height="92" alt="image" src="https://github.com/user-attachments/assets/33cf399f-4381-4dc3-95b8-1e6c13738116" />
