### PR TITLE
fixed home section  logo bug  #26

### DIFF
--- a/src/components/sections/HeroSection.tsx
+++ b/src/components/sections/HeroSection.tsx
@@ -91,7 +91,7 @@ const HeroSection: React.FC = () => {
           <motion.div
             variants={itemVariants}
             whileHover={{ scale: 1.05 }}
-            className='w-24 h-24 bg-gradient-to-br from-[#3b9df0] to-[#1f84d6] rounded-xl flex items-center justify-center mx-auto mt-12 mb-6 shadow-lg cursor-pointer'>
+            className='w-24 h-24 bg-gradient-to-br from-[#3b9df0] to-[#1f84d6] rounded-xl flex items-center justify-center mx-auto mt-20 mb-6 shadow-lg cursor-pointer'>
             <FaGlobe size={64} className='text-white' />
           </motion.div>
 


### PR DESCRIPTION
fixed home section  logo  that over laping in navbar  #26 
<img width="1920" height="880" alt="Screenshot (246)" src="https://github.com/user-attachments/assets/e72ab704-d7f7-4383-b1c0-285552dac9a4" />
