### PR TITLE
fix: Remove broken LinkedIn link from Contact section

### DIFF
--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -51,13 +51,14 @@ const ContactSection: React.FC = () => {
       color: theme === "light" ? "hover:bg-gray-800" : "hover:bg-gray-600",
       description: "Contribute to our projects",
     },
-    {
-      name: "LinkedIn",
-      icon: FaLinkedin,
-      url: "https://linkedin.com/company/open-source-world",
-      color: "hover:bg-blue-600",
-      description: "Professional network",
-    },
+    // LinkedIn link temporarily removed - company page needs to be created
+    // {
+    //   name: "LinkedIn",
+    //   icon: FaLinkedin,
+    //   url: "https://linkedin.com/company/open-source-world",
+    //   color: "hover:bg-blue-600",
+    //   description: "Professional network",
+    // },
     {
       name: "Discord",
       icon: FaDiscord,


### PR DESCRIPTION
fixed issue #33 
🎯 Impact:
Users will no longer encounter the broken LinkedIn link in the Contact section
The remaining social links (GitHub, Discord, YouTube, Instagram) are still functional
The code is preserved for easy restoration when a valid LinkedIn page becomes available